### PR TITLE
bump conda-mirror to 0.7.3

### DIFF
--- a/cmirror/Dockerfile
+++ b/cmirror/Dockerfile
@@ -10,7 +10,7 @@ COPY scripts/install_miniconda.sh /root/
 ENV MINICONDA_VERSION=4.2.12
 RUN chmod a+x /root/install_miniconda.sh && /root/install_miniconda.sh
 RUN echo 'PATH=$PATH:/miniconda/bin' > /etc/profile.d/miniconda.sh
-RUN /miniconda/bin/pip install conda-mirror==0.6.5
+RUN /miniconda/bin/pip install conda-mirror==0.7.3
 
 RUN yum clean all
 


### PR DESCRIPTION
Includes the requested concurrent package validation:

https://github.com/maxpoint/conda-mirror/issues/43